### PR TITLE
fix implicit relative import, and py3 compatibility

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -26,6 +26,11 @@ Figure 1: Original image and the reconstructed versions from maxpool layer 1,2 a
 * h5py
 * wget
 * Pillow
+* six
+
+If you are using pip you can install these with
+
+```pip install tensorflow numpy scipy h5py wget Pillow six```
 
 ## Setup script
 Clone the repository

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 import pkgutil
 
 # required pkgs
-dependencies = ['numpy', 'scipy', 'tensorflow', 'h5py', 'wget', 'Pillow']
+dependencies = ['numpy', 'scipy', 'tensorflow', 'h5py', 'wget', 'Pillow', 'six']
 
 try: 
 	from setuptools import setup

--- a/tf_cnnvis/__init__.py
+++ b/tf_cnnvis/__init__.py
@@ -1,1 +1,6 @@
-from tf_cnnvis import *
+from .tf_cnnvis import get_visualization
+from .tf_cnnvis import image_normalization
+from .tf_cnnvis import convert_into_grid
+
+__all__ = ["get_visualization", "image_normalization", "convert_into_grid"]
+

--- a/tf_cnnvis/tf_cnnvis.py
+++ b/tf_cnnvis/tf_cnnvis.py
@@ -7,6 +7,8 @@ import tensorflow as tf
 from math import ceil, sqrt
 from scipy.misc import imsave
 from scipy.stats.mstats import winsorize
+from six.moves import range
+from six import string_types
 from tensorflow.python.framework import ops
 from tensorflow.python.ops import gen_nn_ops
 
@@ -132,7 +134,7 @@ def get_visualization(
 
 	if isinstance(graph_or_path, tf.Graph):
 		PATH = _save_model(graph_or_path)
-	elif isinstance(graph_or_path, basestring):
+	elif isinstance(graph_or_path, string_types):
 		PATH = graph_or_path
 	else:
 		print("graph_or_path must be a object of graph or string.")
@@ -350,7 +352,7 @@ def _visualization_by_layer_name(
 				sess.run(tf.global_variables_initializer())
 
 				# Execute the gradient operations in batches of 'n'
-				for i in xrange(0, tensor_shape[-1], n):
+				for i in range(0, tensor_shape[-1], n):
 					c = 0
 					for j in range(n):
 						if (i + j) < tensor_shape[-1]:


### PR DESCRIPTION
Without this, importing the package fails because the name of the module is the same as the name of the package ifself.
This pull request makes the relative import implicit, same problem as in here: https://softwareengineering.stackexchange.com/questions/159503/whats-wrong-with-relative-imports-in-python
Also, this also exports the functions exposed in the API.