### PR TITLE
Visualization of open Sessions and fix to Example 2

### DIFF
--- a/examples/tf_cnnvis_Example1.ipynb
+++ b/examples/tf_cnnvis_Example1.ipynb
@@ -2,8 +2,10 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 15,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# import\n",
@@ -15,13 +17,18 @@
     "import numpy as np\n",
     "import tensorflow as tf\n",
     "from scipy.misc import imread, imresize\n",
-    "from tf_cnnvis import *"
+    "\n",
+    "sys.path.insert(0, r'C:/Users/giann/Projects/tf_cnnvis/tf_cnnvis')\n",
+    "from tf_cnnvis import *\n",
+    "del sys.path[0]"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# download alexnet model weights\n",
@@ -31,8 +38,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# loading parameters and mean image for pretrained alexnet model\n",
@@ -55,11 +64,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# tensorflow model implementation (Alexnet convolution)\n",
+    "tf.reset_default_graph()\n",
+    "\n",
     "X = tf.placeholder(tf.float32, shape = [None, 224, 224, 3]) # placeholder for input images\n",
     "y_ = tf.placeholder(tf.float32, shape = [None, 1000]) # placeholder for true labels for input images\n",
     "\n",
@@ -184,9 +197,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "C:\\Users\\giann\\Anaconda3\\envs\\tensorOCV\\lib\\site-packages\\ipykernel_launcher.py:2: DeprecationWarning: `imread` is deprecated!\n",
+      "`imread` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.\n",
+      "Use ``imageio.imread`` instead.\n",
+      "  \n",
+      "C:\\Users\\giann\\Anaconda3\\envs\\tensorOCV\\lib\\site-packages\\ipykernel_launcher.py:2: DeprecationWarning: `imresize` is deprecated!\n",
+      "`imresize` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.\n",
+      "Use ``skimage.transform.resize`` instead.\n",
+      "  \n",
+      "C:\\Users\\giann\\Anaconda3\\envs\\tensorOCV\\lib\\site-packages\\ipykernel_launcher.py:3: DeprecationWarning: `imresize` is deprecated!\n",
+      "`imresize` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.\n",
+      "Use ``skimage.transform.resize`` instead.\n",
+      "  This is separate from the ipykernel package so we can avoid doing imports until\n"
+     ]
+    }
+   ],
    "source": [
     "# reading sample image\n",
     "im = np.expand_dims(imresize(imresize(imread(os.path.join(\"sample_images\", \"images.jpg\")), (256, 256)) - mean, \n",
@@ -195,15 +229,117 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
+   "source": [
+    "# open a session and initialize graph variables\n",
+    "# CAVEAT: trained alexnet weights have been set as initialization values in the graph nodes.\n",
+    "#         For this reason visualization can be performed just after initialization\n",
+    "sess = tf.Session(graph=tf.get_default_graph())\n",
+    "sess.run(tf.global_variables_initializer())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:tensorflow:Restoring parameters from model\\tmp-model\n",
+      "Reconstruction Completed for conv1 layer. Time taken = 0.197091 s\n",
+      "Reconstruction Completed for conv2_1 layer. Time taken = 0.112829 s\n",
+      "Reconstruction Completed for conv2_2 layer. Time taken = 0.103245 s\n",
+      "Reconstruction Completed for conv3 layer. Time taken = 0.122237 s\n",
+      "Reconstruction Completed for conv4_1 layer. Time taken = 0.096248 s\n",
+      "Reconstruction Completed for conv4_2 layer. Time taken = 0.092852 s\n",
+      "Reconstruction Completed for conv5_1 layer. Time taken = 0.084220 s\n",
+      "Reconstruction Completed for conv5_2 layer. Time taken = 0.088238 s\n",
+      "Skipping. Too many featuremaps. May cause memory errors.\n",
+      "Skipping. Too many featuremaps. May cause memory errors.\n",
+      "Reconstruction Completed for MaxPool layer. Time taken = 0.072814 s\n",
+      "Reconstruction Completed for MaxPool_1 layer. Time taken = 0.064835 s\n",
+      "Reconstruction Completed for MaxPool_2 layer. Time taken = 0.063783 s\n",
+      "Reconstruction Completed for MaxPool_3 layer. Time taken = 0.082376 s\n",
+      "Reconstruction Completed for MaxPool_4 layer. Time taken = 0.071227 s\n",
+      "Reconstruction Completed for Conv2D layer. Time taken = 0.139840 s\n",
+      "Reconstruction Completed for Conv2D_1 layer. Time taken = 0.080081 s\n",
+      "Reconstruction Completed for Conv2D_2 layer. Time taken = 0.079159 s\n",
+      "Reconstruction Completed for Conv2D_3 layer. Time taken = 0.098842 s\n",
+      "Reconstruction Completed for Conv2D_4 layer. Time taken = 0.077548 s\n",
+      "Reconstruction Completed for Conv2D_5 layer. Time taken = 0.079904 s\n",
+      "Reconstruction Completed for Conv2D_6 layer. Time taken = 0.078581 s\n",
+      "Reconstruction Completed for Conv2D_7 layer. Time taken = 0.087942 s\n",
+      "Total Time = 9.390236\n"
+     ]
+    }
+   ],
    "source": [
     "# activation visualization\n",
     "layers = ['r', 'p', 'c']\n",
     "\n",
     "start = time.time()\n",
-    "is_success = activation_visualization(graph_or_path = tf.get_default_graph(), value_feed_dict = {X : im}, \n",
+    "with sess.as_default():\n",
+    "    is_success = activation_visualization(sess_graph_path = None, value_feed_dict = {X : im}, \n",
+    "                                          layers=layers, path_logdir=os.path.join(\"Log\",\"AlexNet\"), \n",
+    "                                          path_outdir=os.path.join(\"Output\",\"AlexNet\"))\n",
+    "start = time.time() - start\n",
+    "print(\"Total Time = %f\" % (start))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "INFO:tensorflow:Restoring parameters from model\\tmp-model\n",
+      "Reconstruction Completed for conv1 layer. Time taken = 6.086680 s\n",
+      "Reconstruction Completed for conv2_1 layer. Time taken = 14.330129 s\n",
+      "Reconstruction Completed for conv2_2 layer. Time taken = 13.539706 s\n",
+      "Reconstruction Completed for conv3 layer. Time taken = 51.389293 s\n",
+      "Reconstruction Completed for conv4_1 layer. Time taken = 27.758152 s\n",
+      "Reconstruction Completed for conv4_2 layer. Time taken = 27.716882 s\n",
+      "Reconstruction Completed for conv5_1 layer. Time taken = 15.138553 s\n",
+      "Reconstruction Completed for conv5_2 layer. Time taken = 17.424449 s\n",
+      "Skipping. Too many featuremaps. May cause memory errors.\n",
+      "Skipping. Too many featuremaps. May cause memory errors.\n",
+      "Reconstruction Completed for MaxPool layer. Time taken = 7.035349 s\n",
+      "Reconstruction Completed for MaxPool_1 layer. Time taken = 14.051594 s\n",
+      "Reconstruction Completed for MaxPool_2 layer. Time taken = 13.250973 s\n",
+      "Reconstruction Completed for MaxPool_3 layer. Time taken = 16.356598 s\n",
+      "Reconstruction Completed for MaxPool_4 layer. Time taken = 17.736508 s\n",
+      "Reconstruction Completed for Conv2D layer. Time taken = 4.783646 s\n",
+      "Reconstruction Completed for Conv2D_1 layer. Time taken = 13.808297 s\n",
+      "Reconstruction Completed for Conv2D_2 layer. Time taken = 11.612177 s\n",
+      "Reconstruction Completed for Conv2D_3 layer. Time taken = 49.952301 s\n",
+      "Reconstruction Completed for Conv2D_4 layer. Time taken = 28.501087 s\n",
+      "Reconstruction Completed for Conv2D_5 layer. Time taken = 29.194505 s\n",
+      "Reconstruction Completed for Conv2D_6 layer. Time taken = 19.683325 s\n",
+      "Reconstruction Completed for Conv2D_7 layer. Time taken = 20.473815 s\n",
+      "Total Time = 430.320485\n"
+     ]
+    }
+   ],
+   "source": [
+    "# deconv visualization\n",
+    "layers = ['r', 'p', 'c']\n",
+    "\n",
+    "start = time.time()\n",
+    "with sess.as_default():\n",
+    "    is_success = deconv_visualization(sess_or_path = None, value_feed_dict = {X : im}, \n",
     "                                      layers=layers, path_logdir=os.path.join(\"Log\",\"AlexNet\"), \n",
     "                                      path_outdir=os.path.join(\"Output\",\"AlexNet\"))\n",
     "start = time.time() - start\n",
@@ -212,46 +348,44 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
+   "execution_count": 14,
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
-    "# deconv visualization\n",
-    "layers = ['r', 'p', 'c']\n",
-    "\n",
-    "start = time.time()\n",
-    "is_success = deconv_visualization(graph_or_path = tf.get_default_graph(), value_feed_dict = {X : im}, \n",
-    "                                  layers=layers, path_logdir=os.path.join(\"Log\",\"AlexNet\"), \n",
-    "                                      path_outdir=os.path.join(\"Output\",\"AlexNet\"))\n",
-    "start = time.time() - start\n",
-    "print(\"Total Time = %f\" % (start))"
+    "#close the session and release variables\n",
+    "sess.close()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python TensorOCV",
    "language": "python",
-   "name": "python2"
+   "name": "tensorocv"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/examples/tf_cnnvis_Example1.ipynb
+++ b/examples/tf_cnnvis_Example1.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -18,14 +18,12 @@
     "import tensorflow as tf\n",
     "from scipy.misc import imread, imresize\n",
     "\n",
-    "sys.path.insert(0, r'C:/Users/giann/Projects/tf_cnnvis/tf_cnnvis')\n",
-    "from tf_cnnvis import *\n",
-    "del sys.path[0]"
+    "from tf_cnnvis import *"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -38,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -64,7 +62,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },
@@ -197,30 +195,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "C:\\Users\\giann\\Anaconda3\\envs\\tensorOCV\\lib\\site-packages\\ipykernel_launcher.py:2: DeprecationWarning: `imread` is deprecated!\n",
-      "`imread` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.\n",
-      "Use ``imageio.imread`` instead.\n",
-      "  \n",
-      "C:\\Users\\giann\\Anaconda3\\envs\\tensorOCV\\lib\\site-packages\\ipykernel_launcher.py:2: DeprecationWarning: `imresize` is deprecated!\n",
-      "`imresize` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.\n",
-      "Use ``skimage.transform.resize`` instead.\n",
-      "  \n",
-      "C:\\Users\\giann\\Anaconda3\\envs\\tensorOCV\\lib\\site-packages\\ipykernel_launcher.py:3: DeprecationWarning: `imresize` is deprecated!\n",
-      "`imresize` is deprecated in SciPy 1.0.0, and will be removed in 1.2.0.\n",
-      "Use ``skimage.transform.resize`` instead.\n",
-      "  This is separate from the ipykernel package so we can avoid doing imports until\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# reading sample image\n",
     "im = np.expand_dims(imresize(imresize(imread(os.path.join(\"sample_images\", \"images.jpg\")), (256, 256)) - mean, \n",
@@ -229,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
@@ -244,49 +223,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Restoring parameters from model\\tmp-model\n",
-      "Reconstruction Completed for conv1 layer. Time taken = 0.197091 s\n",
-      "Reconstruction Completed for conv2_1 layer. Time taken = 0.112829 s\n",
-      "Reconstruction Completed for conv2_2 layer. Time taken = 0.103245 s\n",
-      "Reconstruction Completed for conv3 layer. Time taken = 0.122237 s\n",
-      "Reconstruction Completed for conv4_1 layer. Time taken = 0.096248 s\n",
-      "Reconstruction Completed for conv4_2 layer. Time taken = 0.092852 s\n",
-      "Reconstruction Completed for conv5_1 layer. Time taken = 0.084220 s\n",
-      "Reconstruction Completed for conv5_2 layer. Time taken = 0.088238 s\n",
-      "Skipping. Too many featuremaps. May cause memory errors.\n",
-      "Skipping. Too many featuremaps. May cause memory errors.\n",
-      "Reconstruction Completed for MaxPool layer. Time taken = 0.072814 s\n",
-      "Reconstruction Completed for MaxPool_1 layer. Time taken = 0.064835 s\n",
-      "Reconstruction Completed for MaxPool_2 layer. Time taken = 0.063783 s\n",
-      "Reconstruction Completed for MaxPool_3 layer. Time taken = 0.082376 s\n",
-      "Reconstruction Completed for MaxPool_4 layer. Time taken = 0.071227 s\n",
-      "Reconstruction Completed for Conv2D layer. Time taken = 0.139840 s\n",
-      "Reconstruction Completed for Conv2D_1 layer. Time taken = 0.080081 s\n",
-      "Reconstruction Completed for Conv2D_2 layer. Time taken = 0.079159 s\n",
-      "Reconstruction Completed for Conv2D_3 layer. Time taken = 0.098842 s\n",
-      "Reconstruction Completed for Conv2D_4 layer. Time taken = 0.077548 s\n",
-      "Reconstruction Completed for Conv2D_5 layer. Time taken = 0.079904 s\n",
-      "Reconstruction Completed for Conv2D_6 layer. Time taken = 0.078581 s\n",
-      "Reconstruction Completed for Conv2D_7 layer. Time taken = 0.087942 s\n",
-      "Total Time = 9.390236\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# activation visualization\n",
     "layers = ['r', 'p', 'c']\n",
     "\n",
     "start = time.time()\n",
     "with sess.as_default():\n",
+    "# with sess_graph_path = None, the default Session will be used for visualization.\n",
     "    is_success = activation_visualization(sess_graph_path = None, value_feed_dict = {X : im}, \n",
     "                                          layers=layers, path_logdir=os.path.join(\"Log\",\"AlexNet\"), \n",
     "                                          path_outdir=os.path.join(\"Output\",\"AlexNet\"))\n",
@@ -296,50 +244,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "collapsed": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "INFO:tensorflow:Restoring parameters from model\\tmp-model\n",
-      "Reconstruction Completed for conv1 layer. Time taken = 6.086680 s\n",
-      "Reconstruction Completed for conv2_1 layer. Time taken = 14.330129 s\n",
-      "Reconstruction Completed for conv2_2 layer. Time taken = 13.539706 s\n",
-      "Reconstruction Completed for conv3 layer. Time taken = 51.389293 s\n",
-      "Reconstruction Completed for conv4_1 layer. Time taken = 27.758152 s\n",
-      "Reconstruction Completed for conv4_2 layer. Time taken = 27.716882 s\n",
-      "Reconstruction Completed for conv5_1 layer. Time taken = 15.138553 s\n",
-      "Reconstruction Completed for conv5_2 layer. Time taken = 17.424449 s\n",
-      "Skipping. Too many featuremaps. May cause memory errors.\n",
-      "Skipping. Too many featuremaps. May cause memory errors.\n",
-      "Reconstruction Completed for MaxPool layer. Time taken = 7.035349 s\n",
-      "Reconstruction Completed for MaxPool_1 layer. Time taken = 14.051594 s\n",
-      "Reconstruction Completed for MaxPool_2 layer. Time taken = 13.250973 s\n",
-      "Reconstruction Completed for MaxPool_3 layer. Time taken = 16.356598 s\n",
-      "Reconstruction Completed for MaxPool_4 layer. Time taken = 17.736508 s\n",
-      "Reconstruction Completed for Conv2D layer. Time taken = 4.783646 s\n",
-      "Reconstruction Completed for Conv2D_1 layer. Time taken = 13.808297 s\n",
-      "Reconstruction Completed for Conv2D_2 layer. Time taken = 11.612177 s\n",
-      "Reconstruction Completed for Conv2D_3 layer. Time taken = 49.952301 s\n",
-      "Reconstruction Completed for Conv2D_4 layer. Time taken = 28.501087 s\n",
-      "Reconstruction Completed for Conv2D_5 layer. Time taken = 29.194505 s\n",
-      "Reconstruction Completed for Conv2D_6 layer. Time taken = 19.683325 s\n",
-      "Reconstruction Completed for Conv2D_7 layer. Time taken = 20.473815 s\n",
-      "Total Time = 430.320485\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# deconv visualization\n",
     "layers = ['r', 'p', 'c']\n",
     "\n",
     "start = time.time()\n",
     "with sess.as_default():\n",
-    "    is_success = deconv_visualization(sess_or_path = None, value_feed_dict = {X : im}, \n",
+    "    is_success = deconv_visualization(sess_graph_path = None, value_feed_dict = {X : im}, \n",
     "                                      layers=layers, path_logdir=os.path.join(\"Log\",\"AlexNet\"), \n",
     "                                      path_outdir=os.path.join(\"Output\",\"AlexNet\"))\n",
     "start = time.time() - start\n",
@@ -348,7 +264,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "collapsed": true
    },

--- a/examples/tf_cnnvis_Example2.ipynb
+++ b/examples/tf_cnnvis_Example2.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# imports\n",
@@ -11,9 +13,10 @@
     "import sys\n",
     "import time\n",
     "import numpy as np\n",
-    "from tf_cnnvis import *\n",
     "import tensorflow as tf\n",
     "from tensorflow.examples.tutorials.mnist import input_data\n",
+    "\n",
+    "from tf_cnnvis import *\n",
     "\n",
     "np.random.seed(10)\n",
     "\n",
@@ -24,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# helper method to define model\n",
@@ -80,9 +85,15 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
+    "#load graph and data and run training\n",
+    "\n",
+    "tf.reset_default_graph()\n",
+    "\n",
     "# reading data\n",
     "mnist = input_data.read_data_sets('MNIST_data', one_hot=True)\n",
     "\n",
@@ -97,26 +108,30 @@
     "accuracy = tf.reduce_mean(tf.cast(correct_prediction, tf.float32))\n",
     "\n",
     "# trainning CNN\n",
-    "with tf.Session() as sess:\n",
-    "    sess.run(tf.global_variables_initializer())\n",
+    "sess= tf.Session()\n",
+    "\n",
+    "sess.run(tf.global_variables_initializer())\n",
+    "with sess.as_default():\n",
     "    for i in range(1000):\n",
     "        batch = mnist.train.next_batch(50)\n",
     "        if i%100 == 0:\n",
     "            train_accuracy = accuracy.eval(feed_dict={x:batch[0], y_: batch[1], keep_prob: 1.0})\n",
     "            print(\"step %d, training accuracy %g\"%(i, train_accuracy))\n",
     "        train_step.run(feed_dict={x: batch[0], y_: batch[1], keep_prob: 0.5})\n",
-    "\n",
+    "        \n",
     "    print(\"test accuracy %g\"%accuracy.eval(feed_dict={x: mnist.test.images, y_: mnist.test.labels, \n",
     "                                                      keep_prob: 1.0}))\n",
     "\n",
-    "\n",
-    "    feed_dict = {x:batch[0][1:2], y_: batch[1][1:2], keep_prob: 1.0}"
+    "    feed_dict = {x:batch[0][1:2], y_: batch[1][1:2], keep_prob: 1.0}\n",
+    "    "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# deconv visualization\n",
@@ -124,33 +139,73 @@
     "total_time = 0\n",
     "\n",
     "start = time.time()\n",
-    "# api call\n",
-    "is_success = deconv_visualization(graph_or_path = tf.get_default_graph(), value_feed_dict = feed_dict, \n",
+    "    # api call\n",
+    "is_success = deconv_visualization(sess_graph_path = sess, value_feed_dict = feed_dict, \n",
     "                                  input_tensor=x_image, layers=layers, \n",
     "                                  path_logdir=os.path.join(\"Log\",\"MNISTExample\"), \n",
     "                                  path_outdir=os.path.join(\"Output\",\"MNISTExample\"))\n",
     "start = time.time() - start\n",
-    "print(\"Total Time = %f\" % (start))"
+    "print(\"Total Time = %f\" % (start))\n"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# close the session and release variables.\n",
+    "sess.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python TensorOCV",
    "language": "python",
-   "name": "python2"
+   "name": "tensorocv"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,

--- a/examples/tf_cnnvis_Example3.ipynb
+++ b/examples/tf_cnnvis_Example3.ipynb
@@ -3,7 +3,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# import\n",
@@ -13,7 +15,9 @@
     "import copy\n",
     "import h5py\n",
     "import numpy as np\n",
+    "\n",
     "from tf_cnnvis import *\n",
+    "\n",
     "import tensorflow as tf\n",
     "from scipy.misc import imread, imresize"
    ]
@@ -21,7 +25,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# download InceptionV5 model if not\n",
@@ -32,7 +38,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# importing InceptionV5 model\n",
@@ -48,7 +56,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
     "# reading sample image\n",
@@ -58,7 +68,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# deepdream visualization\n",
@@ -71,42 +83,50 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false
+   },
    "outputs": [],
    "source": [
-    "is_success = deepdream_visualization(graph_or_path = tf.get_default_graph(), value_feed_dict = {t_input : im}, \n",
+    "\n",
+    "\n",
+    "is_success = deepdream_visualization(sess_graph_path = tf.get_default_graph(), value_feed_dict = {t_input : im}, \n",
     "                                     layer=layer, classes = [1, 2, 3, 4, 5],\n",
     "                                     path_logdir=os.path.join(\"Log\",\"Inception5\"), \n",
     "                                     path_outdir=os.path.join(\"Output\",\"Inception5\"))\n",
     "start = time.time() - start\n",
-    "print(\"Total Time = %f\" % (start))"
+    "print(\"Total Time = %f\" % (start))\n",
+    "\n"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": []
   }
  ],
  "metadata": {
+  "anaconda-cloud": {},
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python TensorOCV",
    "language": "python",
-   "name": "python2"
+   "name": "tensorocv"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.12"
+   "pygments_lexer": "ipython3",
+   "version": "3.5.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
To my understanding the previous version would only visualize saved session (with PATH input) or Graphs. Graphs for training only store the definition of their weight and biases in variables, the value learnt by training is only part of the open session running the graph. 
Example 1 worked with graph where the variable values to be visualized were set as the initialization values in graph definition. Example 3 worked with a frozen graph where variables had been substituted by constants. Example 2 used the default configuration and actually visualized random weights.
I added support for open Session visualization (alongside frozen graph and path) so that Example 2 could work without modifying the training graph.